### PR TITLE
small cabal URL markup fix

### DIFF
--- a/testloop.cabal
+++ b/testloop.cabal
@@ -21,7 +21,7 @@ description:
   your project's test-suites whenever a haskell source file is
   modified.
 
-  To get started check out http://github.com/roman/testloop
+  To get started check out <http://github.com/roman/testloop>
 
 -- URL for the project homepage or repository.
 homepage:            http://github.com/roman/testloop


### PR DESCRIPTION
Hi, Haddock mangled your URL. You need to surround URLs with pointy brackets. It's a good idea to 'cabal haddock' and look at the generated docs before uploading to Hackage. Thanks.
