### PR TITLE
Removed unix package upper bound and allowed hint dependency to float

### DIFF
--- a/testloop.cabal
+++ b/testloop.cabal
@@ -73,7 +73,7 @@ library
     directory       >= 1.1,
     filepath        == 1.3.*,
     fsnotify        >= 0.0.8,
-    hint            >= 0.3,
+    hint            >= 0.3 && <1,
     mtl             == 2.1.*,
     system-filepath == 0.4.*,
     time            == 1.4.*
@@ -81,7 +81,7 @@ library
 
   if !os(windows)
     build-depends:
-      unix >= 2.2.0.0
+      unix >= 2.2.0.0 && < 2.8
 
 
 source-repository head

--- a/testloop.cabal
+++ b/testloop.cabal
@@ -10,7 +10,7 @@ name:                testloop
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.1.1.0
+version:             0.1.1.1
 
 -- A short (one-line) description of the package.
 synopsis:            Quick feedback loop for test suites
@@ -73,14 +73,15 @@ library
     directory       >= 1.1,
     filepath        == 1.3.*,
     fsnotify        >= 0.0.8,
-    hint            == 0.3.*,
+    hint            >= 0.3,
     mtl             == 2.1.*,
     system-filepath == 0.4.*,
     time            == 1.4.*
 
+
   if !os(windows)
     build-depends:
-      unix >= 2.2.0.0 && < 2.7
+      unix >= 2.2.0.0
 
 
 source-repository head


### PR DESCRIPTION
Fixes issues using testloop with HaskellKoans on recent GHC on Ubuntu.  Resolves roman/testloop#2 and HaskVan/HaskellKoans#9
