### PR TITLE
Build with Stack & LTS Haskell 5.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,5 @@
 \.\#*
 \#*
-dist/
-cabal-dev/
-.cabal-sandbox/
-cabal.sandbox.config
 *_flymake*
-examples/testloop-example/cabal-dev/*
-examples/testloop-example/dist/*
+
+.stack-work/

--- a/examples/testloop-example/README.md
+++ b/examples/testloop-example/README.md
@@ -2,6 +2,6 @@
 
 Requirements:
 
-* cabal-dev
+* [Stack](http://haskellstack.org/)
 
-execute ./startTestLoop.sh in your shell and read instructions.
+Execute `./startTestLoop.sh` in your shell and read instructions.

--- a/examples/testloop-example/startTestLoop.sh
+++ b/examples/testloop-example/startTestLoop.sh
@@ -1,16 +1,11 @@
 #!/bin/bash
 
-function _runCabalSandboxTestLoop {
-    [[ -d ../../.cabal-sandbox ]] || ( cd ../.. && cabal sandbox init && cd -; )
-    cabal sandbox init --sandbox=../../.cabal-sandbox &&
-    cabal sandbox add-source ../../../testloop &&
-    cabal install --only-dependencies --enable-tests &&
-    cabal configure --enable-tests &&
-    cabal build
+function _runStackTestLoop {
+    stack build
     echo -e "\x1B[32mTestLoop Ready\x1B[0m"
     echo -e "Go to \x1B[33mtest/TestSuite.hs\x1B[0m, modify the file and see things running automatically"
     echo ""
-    ./dist/build/testloop/testloop
+    stack exec testloop
 }
 
-command -v cabal && _runCabalSandboxTestLoop
+command -v stack && _runStackTestLoop

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,38 @@
+# For more information, see: http://docs.haskellstack.org/en/stable/yaml_configuration.html
+
+# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
+resolver: lts-5.0
+
+# Local packages, usually specified by relative directory name
+packages:
+- '.'
+- examples/testloop-example/
+
+# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
+extra-deps:
+- fsnotify-0.0.8
+- text-1.2.2.0
+
+# Override default flag values for local packages and extra-deps
+flags: {}
+
+# Extra package databases containing global packages
+extra-package-dbs: []
+
+# Control whether we use the GHC we find on the path
+# system-ghc: true
+
+# Require a specific version of stack, using version ranges
+# require-stack-version: -any # Default
+# require-stack-version: >= 1.0.0
+
+# Override the architecture used by stack, especially useful on Windows
+# arch: i386
+# arch: x86_64
+
+# Extra directories used by stack for building
+# extra-include-dirs: [/path/to/dir]
+# extra-lib-dirs: [/path/to/dir]
+
+# Allow a newer minor version of GHC than the snapshot specifies
+# compiler-check: newer-minor

--- a/testloop.cabal
+++ b/testloop.cabal
@@ -10,7 +10,7 @@ name:                testloop
 -- PVP summary:      +-+------- breaking API changes
 --                   | | +----- non-breaking API additions
 --                   | | | +--- code changes with no API change
-version:             0.1.1.1
+version:             0.1.1.2
 
 -- A short (one-line) description of the package.
 synopsis:            Quick feedback loop for test suites

--- a/testloop.cabal
+++ b/testloop.cabal
@@ -71,12 +71,12 @@ library
     base            >= 4.5 && < 5,
     Cabal           >= 1.14,
     directory       >= 1.1,
-    filepath        == 1.3.*,
+    filepath        >= 1.3.0,
     fsnotify        == 0.0.8,
     hint            >= 0.3 && <1,
-    mtl             == 2.1.*,
+    mtl             >= 2.1.0,
     system-filepath == 0.4.*,
-    time            == 1.4.*
+    time            >= 1.4.0
 
   ghc-options: -Wall
 


### PR DESCRIPTION
My goal here is really ultimately to get [HaskellKoans](https://github.com/HaskVan/HaskellKoans) to build more reliably and repeatably—koans are aimed at beginners and Cabal Hell really does not make for a good first experience, so IMO it would make a lot of sense for that project to target LTS Haskell for stability. It starts with testloop though, I think, because it has been the source of trouble multiple times on multiple machines belonging to people I've tried to help. With issues like HaskVan/HaskellKoans#9 and HaskVan/HaskellKoans#10 it seems that it's not just me.

So this change opens up constraints on several dependencies pretty liberally to get the build working, but Stack's usage of compatibility-controlled package databases should mitigate the risk of breakage a good deal. We still need to step outside LTS 5.0 slightly for fsnotify 0.0.8 (I didn't try more recent versions yet, in light of f1477e88b802), but I believe this switch significantly reduces the scope for problems.

This configuration is working for me and builds and runs the executable correctly for the example project, as documented. If this is accepted and a bumped version is released on Hackage, I will update HaskellKoans build setup next.
